### PR TITLE
test(router): add basic router test

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+APP_KEY=base64:Y9OhSJJogCwV/lUwwgkK0A==
+APP_ENV=testing
+TEST_ENV=framework

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,4 +1,4 @@
-name: test and coverage
+name: unit testing lunox framework
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules/
 dist/
 bin/
-.env
 .chglog/
 coverage/
 test/database/database.sqlite

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ bin/
 *.md
 entry-server.ts
 *.yaml
+coverage/
+storage/

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,6 @@ module.exports = {
       useESM: true,
     },
   },
-  collectCoverage: true,
+  collectCoverage: false,
   coverageReporters: ["text-summary", "html"],
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,6 @@ module.exports = {
       useESM: true,
     },
   },
-  "collectCoverage": true,
-  "coverageReporters": ["text-summary", "html"],
+  collectCoverage: true,
+  coverageReporters: ["text-summary", "html"],
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "prettier --check --plugin-search-dir=. . && eslint .",
     "prettier": "prettier --write --plugin-search-dir=. .",
     "format": "npm run prettier && npm run lint",
-    "test": "TEST_ENV=framework NODE_OPTIONS=--experimental-vm-modules jest --runInBand --verbose"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --verbose"
   },
   "repository": {
     "type": "git",
@@ -71,6 +71,7 @@
     "@types/node": "^16.11.7",
     "@types/pluralize": "^0.0.29",
     "@types/polka": "^0.5.3",
+    "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
     "bcryptjs": "^2.4.3",
@@ -86,6 +87,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "session-file-store": "^1.5.0",
     "sqlite3": "^5.0.3",
+    "supertest": "^6.2.2",
     "svelte": "^3.46.6",
     "ts-jest": "^27.1.4",
     "tslib": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   '@types/node': ^16.11.7
   '@types/pluralize': ^0.0.29
   '@types/polka': ^0.5.3
+  '@types/supertest': ^2.0.12
   '@typescript-eslint/eslint-plugin': ^5.3.1
   '@typescript-eslint/parser': ^5.3.1
   bcryptjs: ^2.4.3
@@ -40,6 +41,7 @@ specifiers:
   session-file-store: ^1.5.0
   sirv: ^1.0.18
   sqlite3: ^5.0.3
+  supertest: ^6.2.2
   svelte: ^3.46.6
   ts-jest: ^27.1.4
   tslib: ^2.3.1
@@ -73,6 +75,7 @@ devDependencies:
   '@types/node': 16.11.11
   '@types/pluralize': 0.0.29
   '@types/polka': 0.5.3
+  '@types/supertest': 2.0.12
   '@typescript-eslint/eslint-plugin': 5.5.0_8078aa6651cb59a720743720029457d0
   '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.5.4
   bcryptjs: 2.4.3
@@ -88,6 +91,7 @@ devDependencies:
   rollup-plugin-terser: 7.0.2_rollup@2.61.1
   session-file-store: 1.5.0
   sqlite3: 5.0.3
+  supertest: 6.2.2
   svelte: 3.46.6
   ts-jest: 27.1.4_0d7b72465c752c55af569adb97e68789
   tslib: 2.3.1
@@ -907,6 +911,10 @@ packages:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
 
+  /@types/cookiejar/2.1.2:
+    resolution: {integrity: sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==}
+    dev: true
+
   /@types/cors/2.8.12:
     resolution: {integrity: sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==}
     dev: true
@@ -1019,6 +1027,19 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/superagent/4.1.15:
+    resolution: {integrity: sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==}
+    dependencies:
+      '@types/cookiejar': 2.1.2
+      '@types/node': 16.11.11
+    dev: true
+
+  /@types/supertest/2.0.12:
+    resolution: {integrity: sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==}
+    dependencies:
+      '@types/superagent': 4.1.15
     dev: true
 
   /@types/trouter/3.1.0:
@@ -1317,7 +1338,6 @@ packages:
 
   /asap/2.0.6:
     resolution: {integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=}
-    dev: false
 
   /asn1.js/5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
@@ -1561,6 +1581,13 @@ packages:
       responselike: 1.0.2
     dev: true
 
+  /call-bind/1.0.2:
+    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+    dependencies:
+      function-bind: 1.1.1
+      get-intrinsic: 1.1.1
+    dev: true
+
   /callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1718,6 +1745,10 @@ packages:
     engines: {node: '>= 12'}
     dev: false
 
+  /component-emitter/1.3.0:
+    resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
+    dev: true
+
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
@@ -1752,6 +1783,10 @@ packages:
     resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /cookiejar/2.1.3:
+    resolution: {integrity: sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==}
+    dev: true
 
   /core-js/3.19.2:
     resolution: {integrity: sha512-ciYCResnLIATSsXuXnIOH4CbdfgV+H1Ltg16hJFN7/v6OxqnFr/IFGeLacaZ+fHLAm0TBbXwNK9/DNBzBUrO/g==}
@@ -1908,7 +1943,6 @@ packages:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
-    dev: false
 
   /diff-sequences/27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
@@ -2457,6 +2491,10 @@ packages:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
     dev: true
 
+  /fast-safe-stringify/2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: true
+
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
@@ -2521,6 +2559,15 @@ packages:
       mime-types: 2.1.34
     dev: true
 
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.34
+    dev: true
+
   /formidable/2.0.1:
     resolution: {integrity: sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==}
     dependencies:
@@ -2528,7 +2575,6 @@ packages:
       hexoid: 1.0.0
       once: 1.4.0
       qs: 6.9.3
-    dev: false
 
   /fs-extra/8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
@@ -2614,6 +2660,14 @@ packages:
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
+  /get-intrinsic/1.1.1:
+    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==}
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.3
     dev: true
 
   /get-package-type/0.1.0:
@@ -2733,6 +2787,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /has-symbols/1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /has-unicode/2.0.1:
     resolution: {integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=}
     dev: true
@@ -2752,7 +2811,6 @@ packages:
   /hexoid/1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
     engines: {node: '>=8'}
-    dev: false
 
   /html-encoding-sniffer/2.0.1:
     resolution: {integrity: sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==}
@@ -3829,6 +3887,11 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
+  /methods/1.1.2:
+    resolution: {integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=}
+    engines: {node: '>= 0.6'}
+    dev: true
+
   /micromatch/4.0.4:
     resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
     engines: {node: '>=8.6'}
@@ -3851,7 +3914,6 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
-    dev: false
 
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -4106,6 +4168,10 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /object-inspect/1.12.0:
+    resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
     dev: true
 
   /objection/3.0.0_knex@0.95.14:
@@ -4405,10 +4471,16 @@ packages:
       escape-goat: 2.1.1
     dev: true
 
+  /qs/6.10.3:
+    resolution: {integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: true
+
   /qs/6.9.3:
     resolution: {integrity: sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==}
     engines: {node: '>=0.6'}
-    dev: false
 
   /querystring/0.2.0:
     resolution: {integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=}
@@ -4705,6 +4777,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /side-channel/1.0.4:
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.1.1
+      object-inspect: 1.12.0
+    dev: true
+
   /signal-exit/3.0.6:
     resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==}
     dev: true
@@ -4883,6 +4963,36 @@ packages:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
     dev: false
+
+  /superagent/7.1.2:
+    resolution: {integrity: sha512-o9/fP6dww7a4xmEF5a484o2rG34UUGo8ztDlv7vbCWuqPhpndMi0f7eXxdlryk5U12Kzy46nh8eNpLAJ93Alsg==}
+    engines: {node: '>=6.4.0 <13 || >=14'}
+    deprecated: Deprecated due to bug in CI build https://github.com/visionmedia/superagent/pull/1677\#issuecomment-1081361876
+    dependencies:
+      component-emitter: 1.3.0
+      cookiejar: 2.1.3
+      debug: 4.3.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.0
+      formidable: 2.0.1
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.10.3
+      readable-stream: 3.6.0
+      semver: 7.3.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /supertest/6.2.2:
+    resolution: {integrity: sha512-wCw9WhAtKJsBvh07RaS+/By91NNE0Wh0DN19/hWPlBOU8tAfOtbZoVSV4xXeoKoxgPx0rx2y+y+8660XtE7jzg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      methods: 1.1.2
+      superagent: 7.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -52,6 +52,7 @@ export default [
       "cookie",
       "repl",
       "util/types",
+      "supertest"
     ],
   },
   {

--- a/src/Database/DatabaseManager.ts
+++ b/src/Database/DatabaseManager.ts
@@ -104,7 +104,7 @@ class DatabaseManager {
     return this.db.table(table);
   }
 
-  public raw(value: Knex.Value){
+  public raw(value: Knex.Value) {
     return this.db.raw(value);
   }
 

--- a/src/Testing/TestCase.ts
+++ b/src/Testing/TestCase.ts
@@ -1,18 +1,25 @@
 import { DB } from "../Database";
 import type { Application } from "../Foundation";
+import supertest, { SuperAgentTest } from "supertest";
+import type { Polka } from "polka";
 
 abstract class TestCase {
   protected app!: Application;
 
+  protected agent!: SuperAgentTest;
+
   public static make<T extends TestCase>(this: new () => T) {
     const test = new this();
-    beforeAll(() => {
-      return test.setUp();
+    beforeAll(async () => {
+      await test.setUp();
+      test.setAgent(supertest.agent(test.app.make<Polka>("server").handler));
     });
 
     afterAll(() => {
       return test.tearDown();
     });
+
+    return test;
   }
   /**
    * Setup the test environment
@@ -42,6 +49,20 @@ abstract class TestCase {
   protected tearDown() {
     // Closing the DB connection allows Jest to exit successfully.
     return DB.getDb()?.destroy();
+  }
+
+  /**
+   * set superagent instance for http testing
+   */
+  public setAgent(agent: SuperAgentTest) {
+    this.agent = agent;
+  }
+
+  /**
+   * superagent get url
+   */
+  public get(url: string) {
+    return this.agent.get(url);
   }
 }
 

--- a/src/Testing/TestCase.ts
+++ b/src/Testing/TestCase.ts
@@ -1,18 +1,16 @@
 import { DB } from "../Database";
 import type { Application } from "../Foundation";
-import supertest, { SuperAgentTest } from "supertest";
+import supertest from "supertest";
 import type { Polka } from "polka";
 
 abstract class TestCase {
   protected app!: Application;
 
-  protected agent!: SuperAgentTest;
-
   public static make<T extends TestCase>(this: new () => T) {
     const test = new this();
     beforeAll(async () => {
       await test.setUp();
-      test.setAgent(supertest.agent(test.app.make<Polka>("server").handler));
+      global.agent = supertest.agent(test.app.make<Polka>("server").handler);
     });
 
     afterAll(() => {
@@ -49,20 +47,6 @@ abstract class TestCase {
   protected tearDown() {
     // Closing the DB connection allows Jest to exit successfully.
     return DB.getDb()?.destroy();
-  }
-
-  /**
-   * set superagent instance for http testing
-   */
-  public setAgent(agent: SuperAgentTest) {
-    this.agent = agent;
-  }
-
-  /**
-   * superagent get url
-   */
-  public get(url: string) {
-    return this.agent.get(url);
   }
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,6 +11,7 @@ import View from "./Support/Facades/View";
 import crypto from "crypto";
 import fs from "fs";
 import { isProxy } from "util/types";
+import type { SuperAgentTest } from "supertest";
 
 declare global {
   interface Window {
@@ -39,6 +40,7 @@ declare global {
   ) => void;
   var is_class: (instance: any) => boolean;
   var walkDir: (path: string) => Promise<string[]>;
+  var agent: SuperAgentTest;
 }
 
 global.get_current_dir = (importMetaUrl: string) => {

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/Feature/database.test.ts
+++ b/test/Feature/database.test.ts
@@ -5,7 +5,7 @@ import TestCase from "../TestCase";
 TestCase.make();
 
 describe("Database Testing", () => {
-  test("can use query builder to access database", async()=>{
+  test("can use query builder to access database", async () => {
     const users = await DB.table("users").first();
     expect(users).toMatchObject({
       username: "user",
@@ -14,7 +14,7 @@ describe("Database Testing", () => {
     });
   });
 
-  test("can use Model to access database", async ()=>{
+  test("can use Model to access database", async () => {
     const users = await User.query().first();
     expect(users).toMatchObject({
       username: "user",

--- a/test/Feature/router.test.ts
+++ b/test/Feature/router.test.ts
@@ -1,5 +1,6 @@
 import TestCase from "../TestCase";
-const agent = TestCase.make();
+
+TestCase.make();
 
 describe("Router Testing", () => {
   test("can access web routes", async () => {

--- a/test/Feature/router.test.ts
+++ b/test/Feature/router.test.ts
@@ -1,0 +1,17 @@
+import TestCase from "../TestCase";
+const agent = TestCase.make();
+
+describe("Router Testing", () => {
+  test("can access web routes", async () => {
+    const res = await agent.get("/home");
+    expect(res.text).toMatch("welcome to home");
+  });
+
+  test("can access api routes", async () => {
+    const res = await agent.get("/api");
+    expect(res.body).toMatchObject({
+      success: true,
+      message: "OK",
+    });
+  });
+});

--- a/test/TestCase.ts
+++ b/test/TestCase.ts
@@ -8,13 +8,13 @@ class TestCase extends BaseTestCase {
   }
 
   protected async setUp() {
-    if(!this.app){
+    if (!this.app) {
       await this.refreshApplication();
       await this.refreshDatabase();
     }
   }
 
-  public async refreshDatabase(){
+  public async refreshDatabase() {
     const dbConfig = {
       tableName: "migrations",
       directory: "test/database/migrations",

--- a/test/app/Http/Kernel.ts
+++ b/test/app/Http/Kernel.ts
@@ -1,0 +1,15 @@
+import {
+  EncryptCookie,
+  VerifyCsrfToken,
+  Kernel as BaseKernel,
+  StartSession,
+} from "../../../src";
+class Kernel extends BaseKernel {
+  protected middlewareGroups = {
+    web: [EncryptCookie, StartSession, VerifyCsrfToken],
+  };
+
+  protected routeMiddleware = {};
+}
+
+export default Kernel;

--- a/test/app/Model/User.ts
+++ b/test/app/Model/User.ts
@@ -1,6 +1,6 @@
-import { Model } from "../../../src";
+import { Authenticatable, Model, Traitable } from "../../../src";
 
-class User extends Model {
+class User extends Traitable(Model).use(Authenticatable) {
   protected static table = "users";
 }
 

--- a/test/app/Providers/RouteServiceProvider.ts
+++ b/test/app/Providers/RouteServiceProvider.ts
@@ -1,0 +1,11 @@
+import { Route, ServiceProvider } from "../../../src";
+
+class RouteServiceProvider extends ServiceProvider {
+  async register() {}
+  async boot() {
+    await Route.middleware("web").group(base_path("routes/web"));
+    await Route.prefix("/api").group(base_path("routes/api"));
+  }
+}
+
+export default RouteServiceProvider;

--- a/test/bootstrap/app.ts
+++ b/test/bootstrap/app.ts
@@ -1,6 +1,7 @@
-import { Application, Kernel } from "../../src";
+import { Application } from "../../src";
 import path from "path";
 import "../../src/helpers";
+import Kernel from "../app/Http/Kernel";
 
 const basePath = path.join(get_current_dir(import.meta.url), "..");
 const app = new Application(basePath);

--- a/test/config/app.ts
+++ b/test/config/app.ts
@@ -8,6 +8,7 @@ import {
   EncryptionServiceProvider,
 } from "../../src";
 import type { AppConfig } from "../../src/Contracts/Config";
+import RouteServiceProvider from "../app/Providers/RouteServiceProvider";
 
 const app: AppConfig = {
   name: "Lunox App",
@@ -25,6 +26,7 @@ const app: AppConfig = {
     ViewServiceProvider,
 
     // app service providers
+    RouteServiceProvider,
   ],
 };
 export default app;

--- a/test/config/auth.ts
+++ b/test/config/auth.ts
@@ -1,0 +1,109 @@
+import User from "../app/Model/User";
+
+export default {
+  /*
+      |--------------------------------------------------------------------------
+      | Authentication Defaults
+      |--------------------------------------------------------------------------
+      |
+      | This option controls the default authentication "guard" and password
+      | reset options for your application. You may change these defaults
+      | as required, but they're a perfect start for most applications.
+      |
+      */
+
+  defaults: {
+    guard: "web",
+    passwords: "users",
+  },
+
+  /*
+      |--------------------------------------------------------------------------
+      | Authentication Guards
+      |--------------------------------------------------------------------------
+      |
+      | Next, you may define every authentication guard for your application.
+      | Of course, a great default configuration has been defined for you
+      | here which uses session storage and the Eloquent user provider.
+      |
+      | All authentication drivers have a user provider. This defines how the
+      | users are actually retrieved out of your database or other storage
+      | mechanisms used by this application to persist your user's data.
+      |
+      | Supported: "session"
+      |
+      */
+
+  guards: {
+    web: {
+      driver: "session",
+      provider: "users",
+    },
+  },
+
+  /*
+      |--------------------------------------------------------------------------
+      | User Providers
+      |--------------------------------------------------------------------------
+      |
+      | All authentication drivers have a user provider. This defines how the
+      | users are actually retrieved out of your database or other storage
+      | mechanisms used by this application to persist your user's data.
+      |
+      | If you have multiple user tables or models you may configure multiple
+      | sources which represent each model / table. These sources may then
+      | be assigned to any extra authentication guards you have defined.
+      |
+      | Supported: "database", "eloquent"
+      |
+      */
+
+  providers: {
+    users: {
+      driver: "eloquent",
+      model: User,
+    },
+
+    // 'users' : {
+    //     'driver' : 'database',
+    //     'table' : 'users',
+    // },
+  },
+
+  /*
+      |--------------------------------------------------------------------------
+      | Resetting Passwords
+      |--------------------------------------------------------------------------
+      |
+      | You may specify multiple password reset configurations if you have more
+      | than one user table or model in the application and you want to have
+      | separate password reset settings based on the specific user types.
+      |
+      | The expire time is the number of minutes that the reset token should be
+      | considered valid. This security feature keeps tokens short-lived so
+      | they have less time to be guessed. You may change this as needed.
+      |
+      */
+
+  passwords: {
+    users: {
+      provider: "users",
+      table: "password_resets",
+      expire: 60,
+      throttle: 60,
+    },
+  },
+
+  /*
+      |--------------------------------------------------------------------------
+      | Password Confirmation Timeout
+      |--------------------------------------------------------------------------
+      |
+      | Here you may define the amount of seconds before a password confirmation
+      | times out and the user is prompted to re-enter their password via the
+      | confirmation screen. By default, the timeout lasts for three hours.
+      |
+      */
+
+  password_timeout: 10800,
+};

--- a/test/config/session.ts
+++ b/test/config/session.ts
@@ -1,0 +1,183 @@
+import type { SessionConfig } from "../../src/Contracts/Config";
+
+const session: SessionConfig = {
+  /*
+    |--------------------------------------------------------------------------
+    | Default Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default session "driver" that will be used on
+    | requests. By default, we will use the lightweight native driver but
+    | you may specify any of the other wonderful drivers provided here.
+    |
+    | Supported: "file", "cookie", "database", "apc",
+    |            "memcached", "redis", "dynamodb", "array"
+    |
+    */
+
+  driver: env("SESSION_DRIVER", "file"),
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Lifetime
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the number of minutes that you wish the session
+    | to be allowed to remain idle before it expires. If you want them
+    | to immediately expire on the browser closing, set that option.
+    |
+    */
+
+  lifetime: env("SESSION_LIFETIME", 120),
+
+  //   expire_on_close: false,
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session File Location
+    |--------------------------------------------------------------------------
+    |
+    | When using the native session driver, we need a location where session
+    | files may be stored. A default has been set for you but a different
+    | location may be specified. This is only needed for file sessions.
+    |
+    */
+
+  files: storage_path("framework/sessions"),
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" or "redis" session drivers, you may specify a
+    | connection that should be used to manage these sessions. This should
+    | correspond to a connection in your database configuration options.
+    |
+    */
+
+  //   connection: env("SESSION_CONNECTION", null),
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Database Table
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" session driver, you may specify the table we
+    | should use to manage the sessions. Of course, a sensible default is
+    | provided for you; however, you are free to change this as needed.
+    |
+    */
+
+  table: "sessions",
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | While using one of the framework's cache driven session backends you may
+    | list a cache store that should be used for these sessions. This value
+    | must match with one of the application's configured cache "stores".
+    |
+    | Affects: "apc", "dynamodb", "memcached", "redis"
+    |
+    */
+
+  //   store: env("SESSION_STORE", null),
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Sweeping Lottery
+    |--------------------------------------------------------------------------
+    |
+    | Some session drivers must manually sweep their storage location to get
+    | rid of old sessions from storage. Here are the chances that it will
+    | happen on a given request. By default, the odds are 2 out of 100.
+    |
+    */
+
+  // lottery: [2, 100],
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the name of the cookie used to identify a session
+    | instance by ID. The name specified here will get used every time a
+    | new session cookie is created by the framework for every driver.
+    |
+    */
+
+  cookie: env("SESSION_COOKIE", "lunox_session"),
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Path
+    |--------------------------------------------------------------------------
+    |
+    | The session cookie path determines the path for which the cookie will
+    | be regarded as available. Typically, this will be the root path of
+    | your application but you are free to change this when necessary.
+    |
+    */
+
+  path: "/",
+
+  /*
+    |--------------------------------------------------------------------------
+    | Session Cookie Domain
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the domain of the cookie used to identify a session
+    | in your application. This will determine which domains the cookie is
+    | available to in your application. A sensible default has been set.
+    |
+    */
+
+  domain: env("SESSION_DOMAIN", null),
+
+  /*
+    |--------------------------------------------------------------------------
+    | HTTPS Only Cookies
+    |--------------------------------------------------------------------------
+    |
+    | By setting this option to true, session cookies will only be sent back
+    | to the server if the browser has a HTTPS connection. This will keep
+    | the cookie from being sent to you when it can't be done securely.
+    |
+    */
+
+  secure: env("SESSION_SECURE_COOKIE", false),
+
+  /*
+    |--------------------------------------------------------------------------
+    | HTTP Access Only
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will prevent JavaScript from accessing the
+    | value of the cookie and the cookie will only be accessible through
+    | the HTTP protocol. You are free to modify this option if needed.
+    |
+    */
+
+  http_only: true,
+
+  /*
+    |--------------------------------------------------------------------------
+    | Same-Site Cookies
+    |--------------------------------------------------------------------------
+    |
+    | This option determines how your cookies behave when cross-site requests
+    | take place, and can be used to mitigate CSRF attacks. By default, we
+    | will set this value to "lax" since this is a secure default value.
+    |
+    | Supported: "lax", "strict", "none", null
+    |
+    */
+
+  same_site: "lax",
+};
+
+export default session;

--- a/test/database/seeders/DatabaseSeeder.ts
+++ b/test/database/seeders/DatabaseSeeder.ts
@@ -1,7 +1,7 @@
 import { DB, Seeder } from "../../../src";
 import bcrypt from "bcryptjs";
 
-class DatabaseSeeder extends Seeder{
+class DatabaseSeeder extends Seeder {
   public async run() {
     await DB.table("users").insert({
       username: "user",

--- a/test/routes/api.ts
+++ b/test/routes/api.ts
@@ -1,0 +1,8 @@
+import { Route, Response } from "../../src";
+
+Route.get("/", () => {
+  return Response.make({
+    success: true,
+    message: "OK",
+  });
+});

--- a/test/routes/web.ts
+++ b/test/routes/web.ts
@@ -1,0 +1,3 @@
+import { Route } from "../../src";
+
+Route.get("home", () => "welcome to home");


### PR DESCRIPTION
this PR add basic router test using `superagent`.
this is example how to use it in unit testing
```js
TestCase.make();
test("can access web routes", async () => {
  // agent is global superagent instance
    const res = await agent.get("/home");
    expect(res.text).toMatch("welcome to home");
 });
```
this PR also fix github action workflows